### PR TITLE
feat(runtime): add Visibility() string to ProjectInfor

### DIFF
--- a/pkg/runtime/project_resolver.go
+++ b/pkg/runtime/project_resolver.go
@@ -21,6 +21,18 @@ type ProjectResolver interface {
 type ProjectInfor interface {
 	GetProjectID() (string, error)
 	GetProject(v any) error
+
+	// Visibility returns an opaque visibility tag for this project
+	// (e.g. "PUBLIC", "TEAM", "ONLYOWNER"). The concrete string values
+	// are defined by the consumer; sdinsure only guarantees that callers
+	// can retrieve whatever the ProjectGetter stored. An empty string
+	// means unknown / unresolved (e.g. invalidProjectInfor).
+	//
+	// This exists so consumers don't need to round-trip through
+	// GetProject(v any) + reflection + field pluck just to read a
+	// well-known tag; visibility is queried on the authorization hot
+	// path for every guarded RPC.
+	Visibility() string
 }
 
 func NewProjectResolver(log logger.Logger, projectGetter ProjectGetter) *projectResolver {
@@ -96,4 +108,8 @@ func (i invalidProjectInfor) GetProjectID() (string, error) {
 
 func (i invalidProjectInfor) GetProject(v any) error {
 	return sdinsureerrors.NewBadParamsError(errors.New("invalid projectid"))
+}
+
+func (i invalidProjectInfor) Visibility() string {
+	return ""
 }


### PR DESCRIPTION
Authorization middleware needs to read a project's visibility tag (e.g. PUBLIC / TEAM / ONLYOWNER) on every guarded RPC. The current shape forces consumers to round-trip through GetProject(v any) + reflection-fill of a private struct just to pluck a single field, duplicating the same wrapper code in every consumer that wires up authz against a ProjectInfor (in grandturks today there are three near-identical "VisibilityResolver" copies that do exactly this).

Add a typed Visibility() string accessor so consumers can read the tag in one call. The return type is an opaque string — sdinsure doesn't define what values it takes, only that they round-trip intact from whatever the ProjectGetter implementation stored.

Implementation note: invalidProjectInfor returns "" so callers can treat empty as "unknown / unresolved" without nil checks.

This is a breaking interface change — any third-party ProjectInfor implementation must add the method. Known consumers (all in the footprintai org's grandturks repo) will be updated in a follow-up PR alongside the bump of this module version.