### PR TITLE
errors: give *Error a gRPC status so codes survive the transport

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Code int
@@ -160,4 +163,65 @@ func newContextError(err error) *Error {
 	default:
 		return NewUnknownError(err)
 	}
+}
+
+// GRPCStatus maps this error's Code onto a gRPC status.
+//
+// Without it, *Error is an ordinary Go error, so grpc-go classifies every one
+// of them as codes.Unknown. The semantic Code is carried in the message text
+// and nowhere the transport can see it, which means a caller gets the same
+// answer for "you are not authenticated", "that does not exist" and "the
+// database is down".
+//
+// Through grpc-gateway that becomes HTTP 500 for all of them. A missing
+// credential is reported to a browser as a server fault:
+//
+//	{"code":2, "message":"code(3), auth: no valid auth and non-annonymous access"}
+//
+// where code 2 is Unknown and code(3) is CodeInvalidAuth - the real reason,
+// visible only by reading the string. A client cannot act on that: 401 sends
+// you to a login screen, 500 makes you retry.
+//
+// grpc-go looks for this method (status.FromError checks the GRPCStatus
+// interface), so implementing it is all that is needed - no call site changes.
+func (f *Error) GRPCStatus() *status.Status {
+	if f == nil {
+		return status.New(codes.OK, "")
+	}
+	return status.New(f.code.GRPCCode(), f.Error())
+}
+
+// GRPCCode is the gRPC code this Code corresponds to.
+//
+// Kept as a method on Code rather than inline so callers can map without
+// constructing an Error, and so the correspondence is readable in one place.
+func (c Code) GRPCCode() codes.Code {
+	switch c {
+	case CodeNotFound:
+		return codes.NotFound
+	case CodeStatusConflicted:
+		return codes.AlreadyExists
+	case CodeInvalidAuth:
+		// Unauthenticated, not PermissionDenied: this is raised when there is
+		// no usable credential at all, which is 401. PermissionDenied (403)
+		// would say the caller is known and refused, a different thing.
+		return codes.Unauthenticated
+	case CodeBadParameters:
+		return codes.InvalidArgument
+	case CodeTimeout:
+		return codes.DeadlineExceeded
+	case CodeInternal:
+		return codes.Internal
+	case CodeNoMoreRetry:
+		return codes.Aborted
+	case CodeBadGateway:
+		return codes.Unavailable
+	case CodeNotImpl:
+		return codes.Unimplemented
+	case CodeUnknown:
+		return codes.Unknown
+	}
+	// A Code this switch has not been taught about. Unknown is the honest
+	// answer and preserves today's behaviour for it.
+	return codes.Unknown
 }

--- a/pkg/errors/grpcstatus_test.go
+++ b/pkg/errors/grpcstatus_test.go
@@ -1,0 +1,69 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestErrorCarriesItsGRPCStatus is the behaviour that was missing: grpc-go
+// asks an error for its status via the GRPCStatus interface, and without it
+// every *Error was classified codes.Unknown - which grpc-gateway renders as
+// HTTP 500 regardless of what actually went wrong.
+func TestErrorCarriesItsGRPCStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		// The case that prompted this: a request with no credential was
+		// reported to clients as a server fault instead of 401.
+		{"missing credential", NewInvalidAuth(errors.New("no valid auth")), codes.Unauthenticated},
+		{"not found", New(CodeNotFound, errors.New("nope")), codes.NotFound},
+		{"conflict", NewStatusConflicted(errors.New("exists")), codes.AlreadyExists},
+		{"bad parameters", NewBadParamsError(errors.New("bad")), codes.InvalidArgument},
+		{"timeout", NewTimeoutError(errors.New("slow")), codes.DeadlineExceeded},
+		{"internal", NewInternalError(errors.New("boom")), codes.Internal},
+		{"bad gateway", NewBadGatewayError(errors.New("upstream")), codes.Unavailable},
+		{"not implemented", New(CodeNotImpl, errors.New("todo")), codes.Unimplemented},
+		{"unknown stays unknown", NewUnknownError(errors.New("?")), codes.Unknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st, ok := status.FromError(tc.err)
+			if !ok {
+				t.Fatalf("status.FromError did not recognise the error")
+			}
+			if st.Code() != tc.want {
+				t.Errorf("code = %v, want %v", st.Code(), tc.want)
+			}
+			// The original text must survive - callers and logs match on it.
+			if st.Message() != tc.err.Error() {
+				t.Errorf("message = %q, want %q", st.Message(), tc.err.Error())
+			}
+		})
+	}
+}
+
+// A nil *Error must not panic when grpc-go asks it for a status.
+func TestNilErrorStatusIsOK(t *testing.T) {
+	var e *Error
+	if got := e.GRPCStatus().Code(); got != codes.OK {
+		t.Errorf("nil error code = %v, want OK", got)
+	}
+}
+
+// Wrapped errors still resolve, since grpc-go unwraps looking for the
+// interface - this is how the middleware's errors reach the transport.
+func TestWrappedErrorKeepsItsCode(t *testing.T) {
+	wrapped := fmt.Errorf("middleware: %w", NewInvalidAuth(errors.New("no valid auth")))
+	st, ok := status.FromError(wrapped)
+	if !ok {
+		t.Fatal("status.FromError did not recognise the wrapped error")
+	}
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("wrapped code = %v, want Unauthenticated", st.Code())
+	}
+}


### PR DESCRIPTION
`*Error` carries a semantic `Code`, but grpc-go never sees it. Without a `GRPCStatus` method the error is an ordinary Go error, so **every one is classified `codes.Unknown`** — the real reason ends up in the message text and nowhere the transport can read it.

Through grpc-gateway that means **HTTP 500 for everything**. A request with no credential is reported to a browser as a server fault:

```json
{"code":2, "message":"code(3), auth: no valid auth and non-annonymous access"}
```

where `2` is `Unknown` and `code(3)` is `CodeInvalidAuth` — the actual reason, visible only by parsing the string. A client can't act on that: a 401 sends the user to a login screen, a 500 makes them retry something that will never succeed.

## The change

Adds `Error.GRPCStatus()` and `Code.GRPCCode()`:

| Code | gRPC | HTTP |
|---|---|---|
| `CodeNotFound` | `NotFound` | 404 |
| `CodeStatusConflicted` | `AlreadyExists` | 409 |
| `CodeInvalidAuth` | `Unauthenticated` | **401** |
| `CodeBadParameters` | `InvalidArgument` | 400 |
| `CodeTimeout` | `DeadlineExceeded` | 504 |
| `CodeInternal` | `Internal` | 500 |
| `CodeNoMoreRetry` | `Aborted` | 409 |
| `CodeBadGateway` | `Unavailable` | 503 |
| `CodeNotImpl` | `Unimplemented` | 501 |
| `CodeUnknown` | `Unknown` | 500 |

`CodeInvalidAuth` maps to `Unauthenticated`, not `PermissionDenied`, because it's raised at `pkg/grpc/server/middleware/authn/authn.go:105` where there is **no usable credential at all**. `PermissionDenied` would say the caller is known and refused — a different thing, and it would send 403 to someone who simply hasn't logged in.

An unrecognised `Code` returns `Unknown`, so a `Code` added later without touching this switch keeps today's behaviour rather than silently becoming something wrong.

## Compatibility

**No call sites change.** grpc-go finds this through the `GRPCStatus` interface (`status.FromError`), including on wrapped errors — which is how the authn middleware's errors reach the transport. Behaviour is unchanged for `CodeUnknown` and for any code not listed.

Tests cover every mapping, a nil receiver, and a wrapped error. `go build ./...` and `go test ./pkg/errors/` pass.

## How this was found

From the outside, on a deployment using this library through `footprintai/restcol`: an unauthenticated API request returned HTTP 500, which read as an outage rather than a missing login, and took a trace through three repositories to explain. Context: FootprintAI/grandturks#924.

Happy to adjust any mapping if a different correspondence is intended — `CodeInvalidAuth` is the only one I'd consider load-bearing; the rest are the conventional gRPC equivalents.

*(Supersedes #242, which proposed the identical commit from a fork before I had access to branch here.)*