### PR TITLE
errors: map CodeInvalidAuth to PermissionDenied, not Unauthenticated

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -202,10 +202,25 @@ func (c Code) GRPCCode() codes.Code {
 	case CodeStatusConflicted:
 		return codes.AlreadyExists
 	case CodeInvalidAuth:
-		// Unauthenticated, not PermissionDenied: this is raised when there is
-		// no usable credential at all, which is 401. PermissionDenied (403)
-		// would say the caller is known and refused, a different thing.
-		return codes.Unauthenticated
+		// PermissionDenied (403), NOT Unauthenticated (401).
+		//
+		// This code is raised for BOTH kinds of rejection: the authn
+		// middleware uses it when there is no usable credential, and the
+		// authz middleware uses it when a known caller is refused. One code
+		// cannot mean both 401 and 403, so it has to pick the one that is
+		// wrong less often - and telling an authenticated user "log in" is
+		// the more misleading of the two, because it sends them round a loop
+		// that cannot fix anything.
+		//
+		// This also matches what the known consumer already does downstream:
+		// footprintai/grandturks translates CodeInvalidAuth to
+		// PermissionDenied at its middleware edge, with the same reasoning
+		// (grandturks#775).
+		//
+		// Splitting 401 from 403 properly needs a SEPARATE code for "no
+		// credential presented"; that is a wider change than this one and
+		// would want the middlewares updated to use it.
+		return codes.PermissionDenied
 	case CodeBadParameters:
 		return codes.InvalidArgument
 	case CodeTimeout:

--- a/pkg/errors/grpcstatus_test.go
+++ b/pkg/errors/grpcstatus_test.go
@@ -21,7 +21,10 @@ func TestErrorCarriesItsGRPCStatus(t *testing.T) {
 	}{
 		// The case that prompted this: a request with no credential was
 		// reported to clients as a server fault instead of 401.
-		{"missing credential", NewInvalidAuth(errors.New("no valid auth")), codes.Unauthenticated},
+		// CodeInvalidAuth covers BOTH "no credential" and "known caller
+		// refused", so it maps to PermissionDenied - see the switch for why
+		// one code cannot be both 401 and 403.
+		{"invalid auth", NewInvalidAuth(errors.New("no valid auth")), codes.PermissionDenied},
 		{"not found", New(CodeNotFound, errors.New("nope")), codes.NotFound},
 		{"conflict", NewStatusConflicted(errors.New("exists")), codes.AlreadyExists},
 		{"bad parameters", NewBadParamsError(errors.New("bad")), codes.InvalidArgument},
@@ -63,7 +66,7 @@ func TestWrappedErrorKeepsItsCode(t *testing.T) {
 	if !ok {
 		t.Fatal("status.FromError did not recognise the wrapped error")
 	}
-	if st.Code() != codes.Unauthenticated {
-		t.Errorf("wrapped code = %v, want Unauthenticated", st.Code())
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("wrapped code = %v, want PermissionDenied", st.Code())
 	}
 }


### PR DESCRIPTION
Correcting #243, which I got wrong.

`CodeInvalidAuth` is raised for **both** kinds of rejection: the authn middleware uses it when there is no usable credential, and the authz middleware uses it when a **known caller is refused**. #243 mapped it to `Unauthenticated` (401) on the reasoning that it means "not logged in" — true for one caller, wrong for the other.

One code cannot mean both 401 and 403, so it has to pick the one that's wrong less often. **Telling an already-authenticated user to log in is the more misleading of the two** — it sends them round a loop that cannot fix anything, where a 403 at least names the real problem.

## How this was caught

`footprintai/grandturks` already translates `CodeInvalidAuth` → `PermissionDenied` at its own middleware edge, having hit this exact "degrades to Unknown" problem independently (grandturks#775) and fixed it downstream.

#243 **silently overrode that**, because `status.FromError` prefers the error's own `GRPCStatus` over any downstream translation. Three of their tests failed on the dependency bump:

```
--- FAIL: TestSdinsureErrorGetsAGrpcStatus/the_reported_case:_authz_denial_is_PermissionDenied,_not_Unknown
--- FAIL: TestUnaryInterceptorTranslates
--- FAIL: TestStreamInterceptorTranslates
```

That is a good argument for the mapping living here rather than in each consumer — but only if it agrees with what consumers already concluded.

## Not attempted

Splitting 401 from 403 properly needs a **separate code** for "no credential presented", plus the middlewares updated to use it. That's a wider change than this, and worth its own discussion — the honest position today is that this code cannot distinguish them.

Every other mapping from #243 is unchanged. Tests updated; `go build ./...` and `go test ./pkg/errors/` pass.